### PR TITLE
License/frontend license header

### DIFF
--- a/App/app/src/main/java/com/app/appellas/AppApplication.kt
+++ b/App/app/src/main/java/com/app/appellas/AppApplication.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas
 
 import android.app.Application

--- a/App/app/src/main/java/com/app/appellas/data/AppEllasDB.kt
+++ b/App/app/src/main/java/com/app/appellas/data/AppEllasDB.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/data/FCMessagingService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/FCMessagingService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data
 
 import android.app.NotificationChannel

--- a/App/app/src/main/java/com/app/appellas/data/dao/UserDao.kt
+++ b/App/app/src/main/java/com/app/appellas/data/dao/UserDao.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.dao
 
 import androidx.lifecycle.LiveData

--- a/App/app/src/main/java/com/app/appellas/data/models/DataState.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/DataState.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models
 
 data class DataState<out T>(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/ChangePasswordBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/ChangePasswordBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class ChangePasswordBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CheckPointBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CheckPointBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class CheckPointBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateAdvisorBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateAdvisorBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class CreateAdvisorBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateBlogBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateBlogBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class CreateBlogBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateContactBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateContactBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class CreateContactBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateLocationBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/CreateLocationBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class CreateLocationBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/LoginRequest.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/LoginRequest.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class LoginRequest(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/RegisterBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/RegisterBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class RegisterBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/SendCodeBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/SendCodeBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class SendCodeBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/UpdateLocationBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/UpdateLocationBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class UpdateLocationBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/UpdateLocationUserBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/UpdateLocationUserBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class UpdateLocationUserBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/body/VerifyCodeBody.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/body/VerifyCodeBody.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.body
 
 data class VerifyCodeBody(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/BlogsResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/BlogsResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class BlogsResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CheckPointResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CheckPointResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class CheckPointResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/ContactResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/ContactResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class ContactResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateAdvisorResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateAdvisorResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class CreateAdvisorResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateBlogResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateBlogResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class CreateBlogResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateLocationResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/CreateLocationResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class CreateLocationResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/GenericResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/GenericResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 import com.google.gson.annotations.SerializedName

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/LocationResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/LocationResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class LocationResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/LoginResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/LoginResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class LoginResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/dtos/response/RegisterResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/dtos/response/RegisterResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.dtos.response
 
 data class RegisterResponse(

--- a/App/app/src/main/java/com/app/appellas/data/models/entities/Accounts.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/entities/Accounts.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.entities
 
 data class Accounts(

--- a/App/app/src/main/java/com/app/appellas/data/models/entities/User.kt
+++ b/App/app/src/main/java/com/app/appellas/data/models/entities/User.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.models.entities
 
 import androidx.room.Entity

--- a/App/app/src/main/java/com/app/appellas/data/network/ApiResponse.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/ApiResponse.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network
 
 import androidx.annotation.IdRes

--- a/App/app/src/main/java/com/app/appellas/data/network/RetrofitInstance.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/RetrofitInstance.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network
 
 import com.app.appellas.data.network.services.WidgetService

--- a/App/app/src/main/java/com/app/appellas/data/network/services/WidgetService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/WidgetService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services
 
 import com.app.appellas.data.models.dtos.body.CreateLocationBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminAdvisoryService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminAdvisoryService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.admin
 
 import com.app.appellas.data.models.dtos.body.CreateAdvisorBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminLocationServices.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminLocationServices.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.admin
 
 import com.app.appellas.data.models.dtos.body.UpdateLocationBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminUserService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/admin/AdminUserService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.admin
 
 import com.app.appellas.data.models.dtos.response.GenericResponse

--- a/App/app/src/main/java/com/app/appellas/data/network/services/user/BlogService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/user/BlogService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.user
 
 import com.app.appellas.data.models.dtos.response.BlogsResponse

--- a/App/app/src/main/java/com/app/appellas/data/network/services/user/ContactService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/user/ContactService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.user
 
 import com.app.appellas.data.models.dtos.body.CreateContactBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/user/GeozoneService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/user/GeozoneService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.user
 
 import com.app.appellas.data.models.dtos.body.CheckPointBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/user/LocationService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/user/LocationService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.user
 
 import com.app.appellas.data.models.dtos.body.CreateLocationBody

--- a/App/app/src/main/java/com/app/appellas/data/network/services/user/LoginService.kt
+++ b/App/app/src/main/java/com/app/appellas/data/network/services/user/LoginService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.data.network.services.user
 
 import com.app.appellas.data.models.dtos.body.*

--- a/App/app/src/main/java/com/app/appellas/interactors/PostAlertaWigdet.kt
+++ b/App/app/src/main/java/com/app/appellas/interactors/PostAlertaWigdet.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.interactors
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/interactors/PostCheckPoint.kt
+++ b/App/app/src/main/java/com/app/appellas/interactors/PostCheckPoint.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.interactors
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/location/ContextExt.kt
+++ b/App/app/src/main/java/com/app/appellas/location/ContextExt.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.location
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/location/DefaultLocationClient.kt
+++ b/App/app/src/main/java/com/app/appellas/location/DefaultLocationClient.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.location
 
 import android.annotation.SuppressLint

--- a/App/app/src/main/java/com/app/appellas/location/LocationClient.kt
+++ b/App/app/src/main/java/com/app/appellas/location/LocationClient.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.location
 
 import android.location.Location

--- a/App/app/src/main/java/com/app/appellas/location/LocationService.kt
+++ b/App/app/src/main/java/com/app/appellas/location/LocationService.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.location
 
 import android.app.Notification

--- a/App/app/src/main/java/com/app/appellas/repository/admin/AdminAdvisorRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/admin/AdminAdvisorRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.admin
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/admin/AdminLocationRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/admin/AdminLocationRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.admin
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/admin/AdminUserRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/admin/AdminUserRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.admin
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/user/BlogRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/user/BlogRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.user
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/user/ContactRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/user/ContactRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.user
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/user/LocationRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/user/LocationRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.user
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/repository/user/LoginRepository.kt
+++ b/App/app/src/main/java/com/app/appellas/repository/user/LoginRepository.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.repository.user
 
 import com.app.appellas.data.dao.UserDao

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/AccountsAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/AccountsAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.view.LayoutInflater

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/BlogsAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/BlogsAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.view.LayoutInflater

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/ContactAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/ContactAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.view.LayoutInflater

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/LegalAdvisorAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/LegalAdvisorAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.content.Intent

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/MedicalAdvisorAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/MedicalAdvisorAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.content.Intent

--- a/App/app/src/main/java/com/app/appellas/ui/adapters/PsychologistAdvisoryAdapter.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/adapters/PsychologistAdvisoryAdapter.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.adapters
 
 import android.content.Intent

--- a/App/app/src/main/java/com/app/appellas/ui/utils/ConvertBase64.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/utils/ConvertBase64.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.utils
 
 import android.content.ContentResolver

--- a/App/app/src/main/java/com/app/appellas/ui/utils/Extensions.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/utils/Extensions.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.utils
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/utils/LocationUtils.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/utils/LocationUtils.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.utils
 
 import android.app.Activity

--- a/App/app/src/main/java/com/app/appellas/ui/views/activitys/AdminBottomNavActivity.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/activitys/AdminBottomNavActivity.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.activitys
 
 import android.os.Bundle

--- a/App/app/src/main/java/com/app/appellas/ui/views/activitys/BottomNavActivity.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/activitys/BottomNavActivity.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.activitys
 
 import android.os.Bundle

--- a/App/app/src/main/java/com/app/appellas/ui/views/activitys/MainActivity.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/activitys/MainActivity.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.activitys
 
 import androidx.appcompat.app.AppCompatActivity

--- a/App/app/src/main/java/com/app/appellas/ui/views/activitys/SplashActivity.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/activitys/SplashActivity.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.activitys
 
 import android.content.Intent

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminAdvisoryFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminAdvisoryFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminBottomSheetMenuFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminBottomSheetMenuFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminHomeFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminHomeFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminInformationMapFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminInformationMapFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminManageAccountFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/AdminManageAccountFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/CreateAdvisorFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/admin/CreateAdvisorFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.admin
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogAlertFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogAlertFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogConfirmRegister.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogConfirmRegister.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogCreateBlog.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogCreateBlog.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteAccount.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteAccount.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteAdvisor.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteAdvisor.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteContact.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDeleteContact.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDescriptionAlert.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogDescriptionAlert.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogMarkerInformation.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogMarkerInformation.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogReusable.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/dialog/DialogReusable.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.dialog
 
 import android.app.Dialog

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/AdvisoryFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/AdvisoryFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/AlertDetailFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/AlertDetailFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/BlogsFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/BlogsFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/BottomSheetMenuFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/BottomSheetMenuFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/ContactsFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/ContactsFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/CreateBlogFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/CreateBlogFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/CreateContactFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/CreateContactFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.os.Bundle

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/HomeFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/HomeFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.app.Dialog

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/InformationFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/InformationFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/ChangePasswordFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/ChangePasswordFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.login
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/CreateAccountFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/CreateAccountFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.login
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/EnterEmailFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/EnterEmailFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.login
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/LoginFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/LoginFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.login
 
 import android.Manifest

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/VerifyRecoveryCodeFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/login/VerifyRecoveryCodeFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.login
 
 import android.content.Context

--- a/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/profile/ProfileFragment.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/fragments/user/profile/ProfileFragment.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.fragments.user.profile
 
 import android.os.Bundle

--- a/App/app/src/main/java/com/app/appellas/ui/views/widget/AlertWidget.kt
+++ b/App/app/src/main/java/com/app/appellas/ui/views/widget/AlertWidget.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.ui.views.widget
 
 import android.app.PendingIntent

--- a/App/app/src/main/java/com/app/appellas/viewmodel/ViewModelFactory.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/ViewModelFactory.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel
 
 import androidx.lifecycle.ViewModel

--- a/App/app/src/main/java/com/app/appellas/viewmodel/ViewModelProviderFactory.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/ViewModelProviderFactory.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel
 
 import androidx.lifecycle.ViewModel

--- a/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminAdvisorViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminAdvisorViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.admin
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminLocationViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminLocationViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.admin
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminUserViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/admin/AdminUserViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.admin
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/user/AuthViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/user/AuthViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.user
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/user/BlogViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/user/BlogViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.user
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/user/ContactViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/user/ContactViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.user
 
 import android.util.Log

--- a/App/app/src/main/java/com/app/appellas/viewmodel/user/HomeViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/user/HomeViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.user
 
 import androidx.lifecycle.LiveData

--- a/App/app/src/main/java/com/app/appellas/viewmodel/user/LocationViewModel.kt
+++ b/App/app/src/main/java/com/app/appellas/viewmodel/user/LocationViewModel.kt
@@ -1,3 +1,18 @@
+/*
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 package com.app.appellas.viewmodel.user
 
 import android.util.Log

--- a/App/app/src/main/res/layout/activity_main.xml
+++ b/App/app/src/main/res/layout/activity_main.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/admin_advisory_fragment.xml
+++ b/App/app/src/main/res/layout/admin_advisory_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/admin_bottom_nav_activity.xml
+++ b/App/app/src/main/res/layout/admin_bottom_nav_activity.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 

--- a/App/app/src/main/res/layout/admin_bottom_sheet_menu_fragment.xml
+++ b/App/app/src/main/res/layout/admin_bottom_sheet_menu_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/admin_home_fragment.xml
+++ b/App/app/src/main/res/layout/admin_home_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/admin_information.xml
+++ b/App/app/src/main/res/layout/admin_information.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"

--- a/App/app/src/main/res/layout/admin_manage_acc_fragment.xml
+++ b/App/app/src/main/res/layout/admin_manage_acc_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"

--- a/App/app/src/main/res/layout/advisory_fragment.xml
+++ b/App/app/src/main/res/layout/advisory_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"

--- a/App/app/src/main/res/layout/alert_detail_fragment.xml
+++ b/App/app/src/main/res/layout/alert_detail_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/alert_widget.xml
+++ b/App/app/src/main/res/layout/alert_widget.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/Widget.AppEllas.AppWidget.Container"

--- a/App/app/src/main/res/layout/blogs_fragment.xml
+++ b/App/app/src/main/res/layout/blogs_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/bottom_nav_activity.xml
+++ b/App/app/src/main/res/layout/bottom_nav_activity.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 

--- a/App/app/src/main/res/layout/bottom_sheet_menu_fragment.xml
+++ b/App/app/src/main/res/layout/bottom_sheet_menu_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/change_password_fragment.xml
+++ b/App/app/src/main/res/layout/change_password_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/App/app/src/main/res/layout/contacts_fragment.xml
+++ b/App/app/src/main/res/layout/contacts_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/create_account_fragment.xml
+++ b/App/app/src/main/res/layout/create_account_fragment.xml
@@ -1,3 +1,19 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <?xml version="1.0" encoding="utf-8"?>
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/App/app/src/main/res/layout/create_advisor_fragment.xml
+++ b/App/app/src/main/res/layout/create_advisor_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/create_blog_fragment.xml
+++ b/App/app/src/main/res/layout/create_blog_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/create_contact_fragment.xml
+++ b/App/app/src/main/res/layout/create_contact_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_alert.xml
+++ b/App/app/src/main/res/layout/dialog_alert.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_confirm_register.xml
+++ b/App/app/src/main/res/layout/dialog_confirm_register.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_create_blog.xml
+++ b/App/app/src/main/res/layout/dialog_create_blog.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_delete_account.xml
+++ b/App/app/src/main/res/layout/dialog_delete_account.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_delete_advisor.xml
+++ b/App/app/src/main/res/layout/dialog_delete_advisor.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_delete_contact.xml
+++ b/App/app/src/main/res/layout/dialog_delete_contact.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_description_alert.xml
+++ b/App/app/src/main/res/layout/dialog_description_alert.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/dialog_marker_information.xml
+++ b/App/app/src/main/res/layout/dialog_marker_information.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/dialog_reusable.xml
+++ b/App/app/src/main/res/layout/dialog_reusable.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/enter_email_fragment.xml
+++ b/App/app/src/main/res/layout/enter_email_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/App/app/src/main/res/layout/homepage_fragment.xml
+++ b/App/app/src/main/res/layout/homepage_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/information_fragment.xml
+++ b/App/app/src/main/res/layout/information_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/item_account.xml
+++ b/App/app/src/main/res/layout/item_account.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/item_advisory.xml
+++ b/App/app/src/main/res/layout/item_advisory.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/item_blog.xml
+++ b/App/app/src/main/res/layout/item_blog.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/item_contact.xml
+++ b/App/app/src/main/res/layout/item_contact.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/login_fragment.xml
+++ b/App/app/src/main/res/layout/login_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/profile_fragment.xml
+++ b/App/app/src/main/res/layout/profile_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/layout/splash_activity.xml
+++ b/App/app/src/main/res/layout/splash_activity.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/App/app/src/main/res/layout/verify_recover_code_fragment.xml
+++ b/App/app/src/main/res/layout/verify_recover_code_fragment.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/navigation/admin_nav.xml
+++ b/App/app/src/main/res/navigation/admin_nav.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/navigation/home_nav.xml
+++ b/App/app/src/main/res/navigation/home_nav.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/navigation/login_nav.xml
+++ b/App/app/src/main/res/navigation/login_nav.xml
@@ -1,3 +1,19 @@
+
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/App/app/src/main/res/xml/alert_widget_info.xml
+++ b/App/app/src/main/res/xml/alert_widget_info.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/app_widget_description"

--- a/App/app/src/main/res/xml/network_security_config.xml
+++ b/App/app/src/main/res/xml/network_security_config.xml
@@ -1,3 +1,18 @@
+<!-- 
+  Copyright 2023 WeGotYou!
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <base-config cleartextTrafficPermitted="true" />


### PR DESCRIPTION
Se colocó la licencia Apache 2.0 en todos los archivos XML y KT del lado del frontend.